### PR TITLE
Adding setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Guide to Simulating Economic Datasets using WGANs
 
-This repository contains wgan_model, a python module built on PyTorch for using WGANs to simulate from joint and conditional distributions of economic datasets. 
+This repository contains `wgan`, a python module built on PyTorch for using WGANs to simulate from joint and conditional distributions of economic datasets. 
 
 This [Google Colab Notebook](https://colab.research.google.com/drive/1AYvY4ZpCeHjEWLte39CFTs6_KgwRP-N6#scrollTo=NEX_jqVFFwS5) contains a tutorial for the code, including how to install requirements, and estimate and simulate from the resulting models, using a free Google GPU. The tutorial simulates from the Lalonde-Dehejia-Wahba dataset, as described in detail in the following paper. 
 
@@ -14,13 +14,13 @@ The data folder contains the raw Lalonde-Dehejia-Wahba data.
 
 For running the WGAN code outside of a Google Colab environment an installation of [python3](https://www.python.org/downloads/) is required. 
 
-First, clone our repository. 
+In order to install this package and its dependencies, please follows the instructions below.
+
 ``` 
-git clone https://www.github.com/gsbDBI/ds-wgan 
+git clone https://www.github.com/gsbDBI/ds-wgan
+cd ds-wgan
+python setup.py develop 
 ``` 
 
-Then, in the ds-wgan folder, run 
-``` 
-pip install -r requirements.txt 
-```
+
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,1 @@
-numpy
-torch>=1.1.0 
-tqdm 
-tensorboardX>=1.8 
-tensorboard>=2.0.0
-pandas
-matplotlib
-scipy
-git+https://github.com/gbaydin/hypergradient-descent.git
-pyarrow>=0.14 
+.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,44 @@
+from os.path import abspath, dirname, join
+
+from setuptools import setup, find_packages
+
+here = abspath(dirname(__file__))
+
+with open(join(here, 'README.md')) as f:
+    readme = f.read()
+
+# Uncomment once LICENSE is added
+# with open(join(here, 'LICENSE')) as f:
+#     lic = f.read()
+
+setup(name='wgan',
+      version='0.1',
+      description='wgan',
+      author='Jonas Metzger and Evan Munro',
+      long_description=readme,
+      long_description_content_type='text/markdown',
+      url='https://github.com/gsbDBI/ds-wgan',
+      py_modules=['wgan'],
+      install_requires=[
+          "numpy",
+          "torch>=1.1.0",
+          "tqdm",
+          "tensorboardX>=1.8",
+          "tensorboard>=2.0.0",
+          "pandas",
+          "matplotlib",
+          "scipy",
+          "hypergrad @ git+ssh://git@github.com/gbaydin/hypergradient-descent.git",
+          "pyarrow>=0.14",
+      ],
+      classifiers=[
+          'Development Status :: 3 - Alpha',
+          'Intended Audience :: Science/Research',
+          'Topic :: Scientific/Engineering',
+          # Uncomment once license it added
+          # 'License :: OSI Approved :: MIT License',
+          'Programming Language :: Python :: 3'
+      ],
+      # license=lic,
+      # Uncomment when license is approved
+      )


### PR DESCRIPTION
This is necessary if we want call the `wgan` module from outside this repo's folder.

With this in place, a new user can type:

```bash
git clone https://github.com/gsbDBI/ds-wgan
cd ds-wgan
python setup.py develop
```

Notes:
+ I marked the [development status](https://pypi.org/classifiers/) as "alpha"
+ References to LICENCE are commented out, since this repo does not have a LICENSE yet.
+ Dependency requirements are now within the `setup.py`. (Btw, `tqdm` is listed, but it doesn't really seem to be used anywhere)
